### PR TITLE
feat(codemod-html-defaults): codemod removing redundant native HTML attribute defaults

### DIFF
--- a/.changeset/brown-pandas-visit.md
+++ b/.changeset/brown-pandas-visit.md
@@ -1,0 +1,5 @@
+---
+'@dume/codemod-html-defaults': major
+---
+
+Initial release: codemod removing native HTML attributes whose literal value is already the WHATWG spec default (`<input type="text">`, `<form method="get">`, `<script type="text/javascript">`, …). Dry-run by default with a per-attribute report, `--write` to apply, idempotent, byte-preserving outside removals. Defaults sourced from `html-enumerated-attributes` plus a spec-linked supplementary table; contextual defaults (`button[type]`, `target` vs `<base target>`, `link[type]` vs `rel`) are guarded by their real condition or reported for manual review, and dynamic bindings, boolean attributes, custom elements and foreign content are never touched.

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,3 @@
 pnpm-lock.yaml
+# Codemod test fixtures are byte-exact input/expected pairs — formatting them would break the tests
+packages/codemod-html-defaults/tests/fixtures/

--- a/packages/codemod-html-defaults/README.md
+++ b/packages/codemod-html-defaults/README.md
@@ -1,0 +1,75 @@
+# @dume/codemod-html-defaults
+
+Codemod that removes native HTML attributes whose literal value is already the default defined by the [WHATWG HTML Living Standard](https://html.spec.whatwg.org/multipage/) — e.g. `<input type="text">` → `<input>`, `<script type="text/javascript">` → `<script>`, `<form method="get">` → `<form>`.
+
+Lighter markup, less noise, fewer accidentally copy-pasted no-op attributes. Removals are guaranteed spec-level no-ops: everything outside the removed attribute ranges is preserved byte for byte, so the tool is safe on HTML-ish template files (Nunjucks, Jinja…) too.
+
+## Usage
+
+```sh
+# Dry-run (default): report what would be removed, write nothing
+npx codemod-html-defaults src/
+
+# Apply
+npx codemod-html-defaults --write src/
+
+# Include template files when walking directories (explicit file paths are always processed)
+npx codemod-html-defaults --ext html,njk --write .
+```
+
+The run is idempotent: a second pass reports zero removals.
+
+Programmatic API:
+
+```js
+import { transformHtml } from '@dume/codemod-html-defaults';
+
+const { output, findings, changed } = transformHtml('<input type="text">');
+// output === '<input>'
+```
+
+## Where the defaults come from (never from memory)
+
+- **Primary source**: the [`html-enumerated-attributes`](https://github.com/wooorm/html-enumerated-attributes) package (MIT, unified collective), which encodes the WHATWG _missing value default_ of every enumerated attribute as equivalence classes of states. An attribute is removable only when its case-folded value belongs to the same state group as the missing value default.
+- **Supplementary table** (`src/defaults.ts`): the few non-enumerated attributes with a spec-defined default (`script[type]`, `style[type]`, `link[type]`), each entry carrying a link to its normative definition and cross-checked with `html-minifier-terser`'s redundant-attribute handling.
+- **Empirical verification**: the test suite asserts the defaults against jsdom's implementation of the WHATWG reflection rules (`input.type === 'text'`, `form.method === 'get'`, …), and proves on a real form that submission-related behavior is identical before and after the transform.
+
+## What gets removed (unconditionally)
+
+| Example                                                                      | Why it is a no-op                                                                                                                                                                  |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<input type="text">`                                                        | [missing value default: Text](https://html.spec.whatwg.org/multipage/input.html#attr-input-type)                                                                                   |
+| `<form method="get">`                                                        | [missing value default: GET](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-method)                                                               |
+| `<form enctype="application/x-www-form-urlencoded">`                         | [missing value default](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-enctype)                                                                   |
+| `<form autocomplete="on">`                                                   | [missing value default: on](https://html.spec.whatwg.org/multipage/forms.html#attr-form-autocomplete)                                                                              |
+| `<img decoding="auto">`, `<img loading="eager">`, `<iframe loading="eager">` | [decoding](https://html.spec.whatwg.org/multipage/images.html#attr-img-decoding), [loading](https://html.spec.whatwg.org/multipage/urls-and-fetching.html#lazy-loading-attributes) |
+| `<area shape="rect">`                                                        | [missing value default: rectangle](https://html.spec.whatwg.org/multipage/image-maps.html#attr-area-shape)                                                                         |
+| `<textarea wrap="soft">`                                                     | [missing value default: soft](https://html.spec.whatwg.org/multipage/form-elements.html#attr-textarea-wrap)                                                                        |
+| `<script type="text/javascript">`                                            | [omitted attribute means classic script](https://html.spec.whatwg.org/multipage/scripting.html#attr-script-type) — `module`, `importmap` and data blocks are never touched         |
+| `<style type="text/css">`                                                    | [attr-style-type](https://html.spec.whatwg.org/multipage/semantics.html#attr-style-type)                                                                                           |
+| `<ol type="1">`                                                              | missing value default: decimal (case-sensitive comparison)                                                                                                                         |
+
+…plus every other enumerated attribute the data source marks as matching its missing value default (`marquee`, obsolete elements, …). The comparison is exact (no whitespace trimming) and ASCII case-insensitive unless the spec marks the attribute case-sensitive.
+
+## Conditional defaults (the real condition is checked — never a flat default)
+
+| Case                                                   | Handling                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<a target="_self">`, `<area target>`, `<form target>` | Removed **only** in a full document (doctype/`<html>` present) containing **no `<base target>`** — [the missing target falls back to the base element's target](https://html.spec.whatwg.org/multipage/semantics.html#the-base-element). Fragments/partials are always skipped: they may be included under a layout that declares a `<base>`.                                                                                      |
+| `<base target>` itself                                 | Never removed: it sets the document-wide default, removal is not a local no-op.                                                                                                                                                                                                                                                                                                                                                    |
+| `<link type="text/css">`                               | Removed only when the same element has a static `rel` containing the `stylesheet` token — [the default type depends on rel](https://html.spec.whatwg.org/multipage/semantics.html#attr-link-type).                                                                                                                                                                                                                                 |
+| `<button type="submit">`                               | **Never removed in v1**, only reported. The spec's missing value default is the Submit Button state ([attr-button-type](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type)), but the effective behavior depends on form association and historically diverged between browsers outside a form — and explicit `type="submit"`/`type="button"` is often kept deliberately for readability. Left to a human. |
+
+## What is never touched
+
+- **Dynamic values**: template interpolations (`{{ x }}`, `{% if %}`, `<%= %>`, `${x}`) and framework binding attribute names (`:type`, `v-bind:`, `ng-*`…).
+- **Boolean attributes** (`disabled`, `required`, `checked`, `defer`, …): presence is meaning; an attribute with an empty value is never removed either, even when the empty string is the missing value default.
+- **Custom elements** (tag names containing `-`): native defaults do not apply to them.
+- **Foreign content** (SVG/MathML), even when attribute names collide with HTML ones.
+- **Start tags with duplicate attributes**: locations are unreliable there, the whole tag is left alone.
+
+## Scope and relationship to other codemods
+
+This is a **standalone** tool: this repository contains no other markup codemod to share parser infrastructure with, so v1 deliberately targets HTML and HTML-shaped template files only (parse5-based, byte-preserving). JSX/TSX and Vue SFC syntaxes are out of scope for v1 — the dynamic-value and binding guards already refuse to touch such constructs if the tool is pointed at them. If a JSX/Vue-aware codemod appears later, this package's defaults tables and condition layer are reusable as-is; only the per-syntax parsing/edit layer would need to be added.
+
+Documented non-goals of v1, kept as candidates: `td/th[colspan="1"]`/`[rowspan="1"]` (IDL default verified to 1 in tests, but low value), invalid-value canonicalization (e.g. `method="foo"` → GET — a codemod should not rewrite invalid markup silently), `select[size]` (default display size depends on `multiple`).

--- a/packages/codemod-html-defaults/README.md
+++ b/packages/codemod-html-defaults/README.md
@@ -28,6 +28,19 @@ const { output, findings, changed } = transformHtml('<input type="text">');
 // output === '<input>'
 ```
 
+### Codemod CLI workflow entry
+
+For rollouts driven by the [Codemod CLI](https://docs.codemod.com/) (`codemod:ast-grep`-style workflow scripts), the package also exposes a ready-made step with the usual `transform(root) → string | null` contract — drop it into a workflow alongside other transforms:
+
+```js
+// workflow script
+import transform from '@dume/codemod-html-defaults/codemod';
+
+export default transform;
+```
+
+It returns `null` when the file is untouched, logs one `file - Removing N …` line per changed file, and reports conditional skips (`button[type]`, `target` with `<base>`, dynamic values) as `ℹ️` lines so they surface in the rollout output.
+
 ## Where the defaults come from (never from memory)
 
 - **Primary source**: the [`html-enumerated-attributes`](https://github.com/wooorm/html-enumerated-attributes) package (MIT, unified collective), which encodes the WHATWG _missing value default_ of every enumerated attribute as equivalence classes of states. An attribute is removable only when its case-folded value belongs to the same state group as the missing value default.

--- a/packages/codemod-html-defaults/README.md
+++ b/packages/codemod-html-defaults/README.md
@@ -34,6 +34,10 @@ const { output, findings, changed } = transformHtml('<input type="text">');
 - **Supplementary table** (`src/defaults.ts`): the few non-enumerated attributes with a spec-defined default (`script[type]`, `style[type]`, `link[type]`), each entry carrying a link to its normative definition and cross-checked with `html-minifier-terser`'s redundant-attribute handling.
 - **Empirical verification**: the test suite asserts the defaults against jsdom's implementation of the WHATWG reflection rules (`input.type === 'text'`, `form.method === 'get'`, …), and proves on a real form that submission-related behavior is identical before and after the transform.
 
+## Tests
+
+Following the usual codemod convention, the main coverage lives in golden fixtures: each `tests/fixtures/<name>.input.<ext>` file is transformed and compared byte for byte to its `<name>.expected.<ext>` sibling (plus an idempotence check: transforming an expected file must change nothing). To add a case, drop a new input/expected pair in that directory — the harness picks it up automatically. Finer-grained unit specs cover the report contract (findings, skip reasons, line/column) and the assumptions made about the upstream defaults data.
+
 ## What gets removed (unconditionally)
 
 | Example                                                                      | Why it is a no-op                                                                                                                                                                  |

--- a/packages/codemod-html-defaults/bin/codemod-html-defaults.mjs
+++ b/packages/codemod-html-defaults/bin/codemod-html-defaults.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import { run } from '../dist/cli.js';
+
+process.exitCode = await run(process.argv.slice(2));

--- a/packages/codemod-html-defaults/package.json
+++ b/packages/codemod-html-defaults/package.json
@@ -25,6 +25,17 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./codemod": {
+      "types": "./dist/codemod.d.ts",
+      "import": "./dist/codemod.js"
+    },
+    "./package.json": "./package.json"
+  },
   "bin": {
     "codemod-html-defaults": "bin/codemod-html-defaults.mjs"
   },

--- a/packages/codemod-html-defaults/package.json
+++ b/packages/codemod-html-defaults/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@dume/codemod-html-defaults",
+  "version": "0.0.0",
+  "description": "Codemod that removes native HTML attributes whose literal value is already the spec default (e.g. <input type=\"text\">, <script type=\"text/javascript\">).",
+  "keywords": [
+    "codemod",
+    "html",
+    "attributes",
+    "defaults",
+    "whatwg",
+    "cleanup",
+    "cli"
+  ],
+  "homepage": "https://github.com/smndhm/blu/tree/main/packages/codemod-html-defaults#readme",
+  "bugs": {
+    "url": "https://github.com/smndhm/blu/issues"
+  },
+  "license": "MIT",
+  "author": {
+    "name": "Simon Duhem",
+    "email": "simon.duhem@gmail.com",
+    "url": "https://simon.duhem.fr"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "codemod-html-defaults": "bin/codemod-html-defaults.mjs"
+  },
+  "files": [
+    "dist",
+    "bin"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "html-enumerated-attributes": "1.1.1",
+    "parse5": "8.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "26.1.1",
+    "@vitest/coverage-v8": "4.0.18",
+    "jsdom": "28.1.0",
+    "typescript": "5.9.3",
+    "vite": "7.3.1",
+    "vite-plugin-dts": "4.5.4",
+    "vitest": "4.0.18"
+  }
+}

--- a/packages/codemod-html-defaults/src/cli.ts
+++ b/packages/codemod-html-defaults/src/cli.ts
@@ -1,0 +1,97 @@
+import { parseArgs } from 'node:util';
+import { readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { extname, join, relative } from 'node:path';
+import { transformHtml, type Finding } from './transform.js';
+
+const IGNORED_DIRECTORIES = new Set(['node_modules', 'dist', 'build', 'coverage', '.git']);
+
+const HELP = `codemod-html-defaults — remove native HTML attributes whose value is already the spec default
+
+Usage:
+  codemod-html-defaults [options] [paths...]
+
+Paths can be files or directories (default: current directory).
+Directories are walked recursively; node_modules, dist, build, coverage and .git are skipped.
+
+Options:
+  --write         Apply the changes. Without it the codemod runs in dry-run mode and only reports.
+  --ext <list>    Comma-separated extensions handled when walking directories (default: "html,htm").
+                  Files passed explicitly are always processed. Example: --ext html,njk
+  --help          Show this help.
+`;
+
+export interface FileReport {
+  file: string;
+  findings: Finding[];
+  changed: boolean;
+}
+
+async function collectFiles(paths: string[], extensions: Set<string>): Promise<string[]> {
+  const files: string[] = [];
+  const visit = async (path: string, explicit: boolean): Promise<void> => {
+    const stats = await stat(path);
+    if (stats.isDirectory()) {
+      for (const entry of await readdir(path)) {
+        if (IGNORED_DIRECTORIES.has(entry)) continue;
+        await visit(join(path, entry), false);
+      }
+    } else if (explicit || extensions.has(extname(path).slice(1).toLowerCase())) {
+      files.push(path);
+    }
+  };
+  for (const path of paths) await visit(path, true);
+  return files;
+}
+
+export async function processFiles(paths: string[], options: { write: boolean; extensions: string[] }): Promise<FileReport[]> {
+  const files = await collectFiles(paths.length > 0 ? paths : ['.'], new Set(options.extensions.map(extension => extension.toLowerCase())));
+  const reports: FileReport[] = [];
+  for (const file of files) {
+    const source = await readFile(file, 'utf8');
+    const { output, findings, changed } = transformHtml(source);
+    if (changed && options.write) await writeFile(file, output, 'utf8');
+    reports.push({ file, findings, changed });
+  }
+  return reports;
+}
+
+function formatFinding(file: string, finding: Finding): string {
+  const location = `${relative(process.cwd(), file)}:${finding.line}:${finding.column}`;
+  const attribute = `<${finding.tag}> ${finding.attribute}="${finding.value}"`;
+  return finding.type === 'removed' ? `${location} remove ${attribute}` : `${location} skip   ${attribute} (${finding.reason})`;
+}
+
+export async function run(argv: string[]): Promise<number> {
+  const { values, positionals } = parseArgs({
+    args: argv,
+    options: {
+      write: { type: 'boolean', default: false },
+      ext: { type: 'string', default: 'html,htm' },
+      help: { type: 'boolean', default: false },
+    },
+    allowPositionals: true,
+  });
+
+  if (values.help) {
+    console.log(HELP);
+    return 0;
+  }
+
+  const reports = await processFiles(positionals, { write: values.write, extensions: values.ext.split(',').map(extension => extension.trim()) });
+
+  let removed = 0;
+  let skipped = 0;
+  for (const report of reports) {
+    for (const finding of report.findings) {
+      if (finding.type === 'removed') removed += 1;
+      else skipped += 1;
+      console.log(formatFinding(report.file, finding));
+    }
+  }
+
+  const changedFiles = reports.filter(report => report.changed).length;
+  const mode = values.write ? 'written' : 'dry-run';
+  console.log(`\n${removed} removable attribute(s) in ${changedFiles} file(s), ${skipped} skipped — ${reports.length} file(s) scanned [${mode}]`);
+  if (!values.write && removed > 0) console.log('Run again with --write to apply.');
+  return 0;
+}

--- a/packages/codemod-html-defaults/src/codemod.ts
+++ b/packages/codemod-html-defaults/src/codemod.ts
@@ -1,0 +1,37 @@
+import { transformHtml } from './transform.js';
+
+/**
+ * Entry point matching the Codemod CLI (`codemod:ast-grep`) workflow contract:
+ * a default-exported `transform(root)` returning the new source, or `null`
+ * when the file is untouched.
+ *
+ * The runtime provides the `SgRoot`; only the two members below are used, so
+ * they are typed structurally here rather than importing `codemod:ast-grep`
+ * (a virtual module that only resolves inside the Codemod runtime). The
+ * transformation itself does not go through ast-grep: the whole source is
+ * handed to the parse5-based engine, which edits byte ranges and returns the
+ * full file — equivalent to `commitEdits` over the root node.
+ */
+export interface SgRootLike {
+  root(): { text(): string };
+  filename(): string;
+}
+
+async function transform(root: SgRootLike): Promise<string | null> {
+  const source = root.root().text();
+  const fileName = root.filename();
+  const { output, findings, changed } = transformHtml(source);
+
+  const skipped = findings.filter(finding => finding.type === 'skipped');
+  for (const finding of skipped) {
+    console.log(`ℹ️ ${fileName}:${finding.line}:${finding.column} - keeping <${finding.tag}> ${finding.attribute}="${finding.value}" (${finding.reason})`);
+  }
+
+  if (!changed) return null;
+
+  const removed = findings.length - skipped.length;
+  console.log(`${fileName} - Removing ${removed} native HTML default attribute(s)`);
+  return output;
+}
+
+export default transform;

--- a/packages/codemod-html-defaults/src/defaults.ts
+++ b/packages/codemod-html-defaults/src/defaults.ts
@@ -1,0 +1,105 @@
+/**
+ * Sources of truth for "this literal value is already the default" decisions.
+ *
+ * Primary source: the `html-enumerated-attributes` package (MIT, unified
+ * collective), which encodes the WHATWG "missing value default" of every
+ * enumerated HTML attribute as equivalence classes of states. An attribute
+ * is removable when its (case-folded) value belongs to the same state group
+ * as the missing value default — i.e. removing it is a spec-level no-op.
+ *
+ * This module adds two overlays on top of that data:
+ *
+ * 1. `supplementaryRules`: attributes that are NOT enumerated (MIME types),
+ *    so absent from the package, each entry sourced to the WHATWG HTML
+ *    Living Standard and cross-checked with `html-minifier-terser`'s
+ *    redundant-attribute handling.
+ * 2. `conditionalAttributes`: attributes whose default is contextual. These
+ *    are never treated as a flat default — they are either checked against
+ *    the real condition (document scope, sibling attributes) or skipped and
+ *    reported.
+ */
+
+/**
+ * Identifiers of contextual conditions.
+ *
+ * - `no-base-target`: removing `target="_self"` is only a no-op when the
+ *   document contains no `<base target>` (WHATWG: the missing `target`
+ *   falls back to the base element's target). The condition is only
+ *   checkable on a full document — fragments/partials may be included into
+ *   a layout that declares a `<base>`, so they are always skipped.
+ *   https://html.spec.whatwg.org/multipage/semantics.html#the-base-element
+ * - `rel-stylesheet`: `type="text/css"` on `<link>` is only the default
+ *   for `rel="stylesheet"` links.
+ *   https://html.spec.whatwg.org/multipage/semantics.html#attr-link-type
+ * - `form-association`: `<button type="submit">` is the missing value
+ *   default per spec, but the effective behavior of a button depends on its
+ *   form association (and historically diverged between browsers outside a
+ *   form). Not automated in v1: always skipped and reported for manual
+ *   review. https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type
+ * - `excluded`: never removable; removing it would not be a local no-op at
+ *   all (e.g. `target` on `<base>` sets the default for the whole document).
+ */
+export type ConditionId = 'no-base-target' | 'rel-stylesheet' | 'form-association' | 'excluded';
+
+export interface SupplementaryRule {
+  tag: string;
+  attribute: string;
+  /** Lowercased literal values equivalent to the attribute being absent. */
+  equivalentToMissing: string[];
+  condition?: ConditionId;
+  /** Link to the normative definition this entry was checked against. */
+  source: string;
+  note: string;
+}
+
+/**
+ * Non-enumerated attributes with a spec-defined default, verified entry by
+ * entry against the WHATWG HTML Living Standard.
+ */
+export const supplementaryRules: SupplementaryRule[] = [
+  {
+    tag: 'script',
+    attribute: 'type',
+    equivalentToMissing: ['text/javascript'],
+    source: 'https://html.spec.whatwg.org/multipage/scripting.html#attr-script-type',
+    note:
+      'Omitting the attribute, setting it to the empty string, or setting it to a JavaScript MIME type essence match all mean "classic script"; ' +
+      'only the canonical `text/javascript` is removed (never `module`, `importmap`, or data blocks). ' +
+      'Cross-checked with html-minifier-terser `removeScriptTypeAttributes`.',
+  },
+  {
+    tag: 'style',
+    attribute: 'type',
+    equivalentToMissing: ['text/css'],
+    source: 'https://html.spec.whatwg.org/multipage/semantics.html#attr-style-type',
+    note: 'The type attribute of <style>, if present, must be `text/css` (ASCII case-insensitive); omitting it has the same meaning. Cross-checked with html-minifier-terser `removeStyleLinkTypeAttributes`.',
+  },
+  {
+    tag: 'link',
+    attribute: 'type',
+    equivalentToMissing: ['text/css'],
+    condition: 'rel-stylesheet',
+    source: 'https://html.spec.whatwg.org/multipage/semantics.html#attr-link-type',
+    note: 'For `rel="stylesheet"` links the default type is `text/css`; for any other rel the type attribute is meaningful and kept.',
+  },
+];
+
+/**
+ * Attributes present in the enumerated-attributes data whose "missing value
+ * default" is contextual and must not be applied flatly.
+ */
+export const conditionalAttributes: Record<string, Record<string, ConditionId>> = {
+  a: { target: 'no-base-target' },
+  area: { target: 'no-base-target' },
+  form: { target: 'no-base-target' },
+  base: { target: 'excluded' },
+  button: { type: 'form-association' },
+};
+
+/** Human-readable reasons used in dry-run reports for skipped conditionals. */
+export const conditionReasons: Record<ConditionId, string> = {
+  'no-base-target': 'target defaults depend on <base target>; only removed in a full document without one',
+  'rel-stylesheet': 'type="text/css" is only the default when rel="stylesheet"',
+  'form-association': 'button[type] default depends on form association; left for manual review (v1)',
+  'excluded': 'never a local no-op (e.g. <base target> sets the document-wide default)',
+};

--- a/packages/codemod-html-defaults/src/index.ts
+++ b/packages/codemod-html-defaults/src/index.ts
@@ -1,3 +1,4 @@
 export { transformHtml, type Finding, type TransformResult } from './transform.js';
 export { supplementaryRules, conditionalAttributes, conditionReasons, type ConditionId, type SupplementaryRule } from './defaults.js';
 export { processFiles, run, type FileReport } from './cli.js';
+export { default as codemodTransform, type SgRootLike } from './codemod.js';

--- a/packages/codemod-html-defaults/src/index.ts
+++ b/packages/codemod-html-defaults/src/index.ts
@@ -1,0 +1,3 @@
+export { transformHtml, type Finding, type TransformResult } from './transform.js';
+export { supplementaryRules, conditionalAttributes, conditionReasons, type ConditionId, type SupplementaryRule } from './defaults.js';
+export { processFiles, run, type FileReport } from './cli.js';

--- a/packages/codemod-html-defaults/src/transform.ts
+++ b/packages/codemod-html-defaults/src/transform.ts
@@ -1,0 +1,197 @@
+import { ErrorCodes, parse, parseFragment } from 'parse5';
+import type { DefaultTreeAdapterMap, ParserError } from 'parse5';
+import { enumeratedAttributes, type Definition } from 'html-enumerated-attributes';
+import { conditionalAttributes, conditionReasons, supplementaryRules, type ConditionId } from './defaults.js';
+
+type Element = DefaultTreeAdapterMap['element'];
+type ParentNode = DefaultTreeAdapterMap['parentNode'];
+type Node = DefaultTreeAdapterMap['node'];
+
+const HTML_NS = 'http://www.w3.org/1999/xhtml';
+
+/** Template syntaxes (Nunjucks/Jinja, Angular/Vue interpolation, EJS, template literals) that make a value dynamic. */
+const DYNAMIC_VALUE = /\{\{|\{%|<%|\$\{/;
+
+export interface Finding {
+  type: 'removed' | 'skipped';
+  tag: string;
+  attribute: string;
+  value: string;
+  line: number;
+  column: number;
+  reason?: string;
+}
+
+export interface TransformResult {
+  output: string;
+  findings: Finding[];
+  changed: boolean;
+}
+
+interface DocumentContext {
+  isFullDocument: boolean;
+  hasBaseTarget: boolean;
+}
+
+interface Removal {
+  startOffset: number;
+  endOffset: number;
+}
+
+function isElement(node: Node): node is Element {
+  return 'tagName' in node;
+}
+
+function* walk(parent: ParentNode): Generator<Element> {
+  for (const child of parent.childNodes) {
+    if (!isElement(child)) continue;
+    yield child;
+    if ('content' in child) yield* walk(child.content);
+    yield* walk(child);
+  }
+}
+
+function getAttribute(element: Element, name: string): string | undefined {
+  return element.attrs.find(attribute => attribute.name === name)?.value;
+}
+
+/**
+ * True when `value` is in the same state group as the definition's missing
+ * value default, i.e. removing the attribute is a spec-level no-op.
+ */
+function matchesMissingValueDefault(definition: Definition, value: string): boolean {
+  if (typeof definition.missing !== 'string') return false;
+  const folded = definition.caseSensitive ? value : value.toLowerCase();
+  for (const state of definition.states) {
+    if (state === null) continue;
+    const group = Array.isArray(state) ? state : [state];
+    if (group.includes(folded)) return group.includes(definition.missing);
+  }
+  return false;
+}
+
+/** Selectors in the enumerated-attributes data are plain comma-separated tag names; anything else is treated as non-matching for safety. */
+function selectorMatchesTag(selector: string | undefined, tagName: string): boolean {
+  if (selector === undefined) return true;
+  return selector.split(',').some(part => part.trim() === tagName);
+}
+
+function findEnumeratedDefinition(tagName: string, attributeName: string): Definition | undefined {
+  const entry = (enumeratedAttributes as Record<string, Definition | Definition[]>)[attributeName];
+  if (!entry) return undefined;
+  const definitions = Array.isArray(entry) ? entry : [entry];
+  return definitions.find(definition => selectorMatchesTag(definition.selector, tagName));
+}
+
+/** True when the attribute appears in one of the defaults tables, whatever its value. */
+function isKnownAttribute(tagName: string, attributeName: string): boolean {
+  return supplementaryRules.some(rule => rule.tag === tagName && rule.attribute === attributeName) || findEnumeratedDefinition(tagName, attributeName) !== undefined;
+}
+
+/** True when removing the attribute with this literal value is a spec-level no-op, conditions aside. */
+function isRemovableDefault(tagName: string, attributeName: string, value: string): boolean {
+  const supplementary = supplementaryRules.find(rule => rule.tag === tagName && rule.attribute === attributeName);
+  if (supplementary) return supplementary.equivalentToMissing.includes(value.toLowerCase());
+  const definition = findEnumeratedDefinition(tagName, attributeName);
+  return definition !== undefined && matchesMissingValueDefault(definition, value);
+}
+
+function resolveCondition(condition: ConditionId, element: Element, context: DocumentContext): boolean {
+  switch (condition) {
+    case 'no-base-target':
+      return context.isFullDocument && !context.hasBaseTarget;
+    case 'rel-stylesheet': {
+      const rel = getAttribute(element, 'rel');
+      return rel !== undefined && !DYNAMIC_VALUE.test(rel) && rel.toLowerCase().split(/\s+/).includes('stylesheet');
+    }
+    case 'form-association':
+    case 'excluded':
+      return false;
+  }
+}
+
+function conditionFor(tagName: string, attributeName: string): ConditionId | undefined {
+  const supplementary = supplementaryRules.find(rule => rule.tag === tagName && rule.attribute === attributeName);
+  return supplementary?.condition ?? conditionalAttributes[tagName]?.[attributeName];
+}
+
+/**
+ * Remove native HTML attributes whose literal value is already the spec
+ * default. Everything outside the removed attribute ranges is preserved
+ * byte for byte, so the transform is safe on HTML-ish templates (Nunjucks,
+ * Jinja…) as long as removable attributes themselves are static literals.
+ */
+export function transformHtml(source: string): TransformResult {
+  // A start tag containing a duplicate attribute has unreliable attribute locations — leave the whole tag untouched.
+  const duplicateOffsets: number[] = [];
+  const options = {
+    sourceCodeLocationInfo: true,
+    onParseError: (error: ParserError) => {
+      if (error.code === ErrorCodes.duplicateAttribute) duplicateOffsets.push(error.startOffset);
+    },
+  };
+
+  const isFullDocument = /^\s*<!doctype\s/i.test(source) || /<html[\s>]/i.test(source);
+  const tree: ParentNode = isFullDocument ? parse(source, options) : parseFragment(source, options);
+
+  const context: DocumentContext = { isFullDocument, hasBaseTarget: false };
+  for (const element of walk(tree)) {
+    if (element.tagName === 'base' && element.namespaceURI === HTML_NS && getAttribute(element, 'target') !== undefined) {
+      context.hasBaseTarget = true;
+    }
+  }
+
+  const findings: Finding[] = [];
+  const removals: Removal[] = [];
+
+  for (const element of walk(tree)) {
+    if (element.namespaceURI !== HTML_NS) continue;
+    // Custom elements define their own semantics; native defaults do not apply.
+    if (element.tagName.includes('-')) continue;
+    const location = element.sourceCodeLocation;
+    if (!location?.startTag || !location.attrs) continue;
+    const { startTag } = location;
+    if (duplicateOffsets.some(offset => offset >= startTag.startOffset && offset < startTag.endOffset)) continue;
+
+    for (const attribute of element.attrs) {
+      const value = attribute.value;
+      // Boolean-style presence (empty value) is never a removable default.
+      if (value === '') continue;
+
+      const attributeLocation = location.attrs[attribute.name];
+      if (!attributeLocation) continue;
+
+      const report = (type: Finding['type'], reason?: string) =>
+        findings.push({ type, tag: element.tagName, attribute: attribute.name, value, line: attributeLocation.startLine, column: attributeLocation.startCol, reason });
+
+      const condition = conditionFor(element.tagName, attribute.name);
+
+      if (DYNAMIC_VALUE.test(value)) {
+        // Only worth reporting when the attribute is one we would otherwise consider.
+        if (condition !== undefined || isKnownAttribute(element.tagName, attribute.name)) {
+          report('skipped', 'dynamic value (template binding or interpolation)');
+        }
+        continue;
+      }
+
+      if (!isRemovableDefault(element.tagName, attribute.name, value)) continue;
+
+      if (condition !== undefined && !resolveCondition(condition, element, context)) {
+        report('skipped', conditionReasons[condition]);
+        continue;
+      }
+
+      let start = attributeLocation.startOffset;
+      while (start > 0 && /\s/.test(source[start - 1])) start -= 1;
+      removals.push({ startOffset: start, endOffset: attributeLocation.endOffset });
+      report('removed');
+    }
+  }
+
+  let output = source;
+  for (const removal of [...removals].sort((a, b) => b.startOffset - a.startOffset)) {
+    output = output.slice(0, removal.startOffset) + output.slice(removal.endOffset);
+  }
+
+  return { output, findings, changed: output !== source };
+}

--- a/packages/codemod-html-defaults/tests/cli.spec.ts
+++ b/packages/codemod-html-defaults/tests/cli.spec.ts
@@ -1,0 +1,98 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { processFiles, run } from '../src/cli.js';
+
+const SAMPLE = '<!doctype html>\n<html><body><form method="get"><input type="text"></form></body></html>\n';
+const CLEANED = '<!doctype html>\n<html><body><form><input></form></body></html>\n';
+
+describe('processFiles', () => {
+  let directory: string;
+
+  beforeEach(async () => {
+    directory = await mkdtemp(join(tmpdir(), 'codemod-html-defaults-'));
+    await writeFile(join(directory, 'page.html'), SAMPLE);
+    await writeFile(join(directory, 'partial.njk'), '<input type="text" value="{{ value }}">\n');
+    await mkdir(join(directory, 'node_modules'));
+    await writeFile(join(directory, 'node_modules', 'dep.html'), SAMPLE);
+  });
+
+  afterEach(async () => {
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  it('dry-run reports without writing', async () => {
+    const reports = await processFiles([directory], { write: false, extensions: ['html'] });
+    expect(reports).toHaveLength(1);
+    expect(reports[0].changed).toBe(true);
+    expect(reports[0].findings.filter(finding => finding.type === 'removed')).toHaveLength(2);
+    expect(await readFile(join(directory, 'page.html'), 'utf8')).toBe(SAMPLE);
+  });
+
+  it('never descends into node_modules', async () => {
+    const reports = await processFiles([directory], { write: false, extensions: ['html'] });
+    expect(reports.map(report => report.file)).toEqual([join(directory, 'page.html')]);
+  });
+
+  it('--write applies the changes and a second run is a no-op', async () => {
+    await processFiles([directory], { write: true, extensions: ['html'] });
+    expect(await readFile(join(directory, 'page.html'), 'utf8')).toBe(CLEANED);
+
+    const second = await processFiles([directory], { write: true, extensions: ['html'] });
+    expect(second[0].changed).toBe(false);
+    expect(await readFile(join(directory, 'page.html'), 'utf8')).toBe(CLEANED);
+  });
+
+  it('handles template files when their extension is opted in, leaving dynamic values alone', async () => {
+    const reports = await processFiles([directory], { write: true, extensions: ['njk'] });
+    expect(reports.map(report => report.file)).toEqual([join(directory, 'partial.njk')]);
+    expect(await readFile(join(directory, 'partial.njk'), 'utf8')).toBe('<input value="{{ value }}">\n');
+  });
+
+  it('processes explicitly passed files regardless of extension filter', async () => {
+    const file = join(directory, 'page.html');
+    const reports = await processFiles([file], { write: false, extensions: ['njk'] });
+    expect(reports.map(report => report.file)).toEqual([file]);
+  });
+});
+
+describe('run', () => {
+  let directory: string;
+  let logged: string[];
+
+  beforeEach(async () => {
+    directory = await mkdtemp(join(tmpdir(), 'codemod-html-defaults-run-'));
+    await writeFile(join(directory, 'page.html'), SAMPLE);
+    logged = [];
+    vi.spyOn(console, 'log').mockImplementation((...parts: unknown[]) => {
+      logged.push(parts.join(' '));
+    });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  it('--help prints usage and exits 0', async () => {
+    expect(await run(['--help'])).toBe(0);
+    expect(logged.join('\n')).toContain('Usage:');
+  });
+
+  it('dry-run reports each finding, the summary, and how to apply', async () => {
+    expect(await run([directory])).toBe(0);
+    const output = logged.join('\n');
+    expect(output).toContain('remove <form> method="get"');
+    expect(output).toContain('remove <input> type="text"');
+    expect(output).toContain('2 removable attribute(s) in 1 file(s), 0 skipped — 1 file(s) scanned [dry-run]');
+    expect(output).toContain('Run again with --write to apply.');
+    expect(await readFile(join(directory, 'page.html'), 'utf8')).toBe(SAMPLE);
+  });
+
+  it('--write applies and reports the written mode', async () => {
+    expect(await run(['--write', directory])).toBe(0);
+    expect(logged.join('\n')).toContain('[written]');
+    expect(await readFile(join(directory, 'page.html'), 'utf8')).toBe(CLEANED);
+  });
+});

--- a/packages/codemod-html-defaults/tests/codemod.spec.ts
+++ b/packages/codemod-html-defaults/tests/codemod.spec.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import transform, { type SgRootLike } from '../src/codemod.js';
+
+const fakeRoot = (source: string, fileName = 'page.html'): SgRootLike => ({
+  root: () => ({ text: () => source }),
+  filename: () => fileName,
+});
+
+describe('codemod workflow entry (codemod:ast-grep contract)', () => {
+  let logged: string[];
+
+  beforeEach(() => {
+    logged = [];
+    vi.spyOn(console, 'log').mockImplementation((...parts: unknown[]) => {
+      logged.push(parts.join(' '));
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the transformed source and logs the file with a count', async () => {
+    const result = await transform(fakeRoot('<form method="get"><input type="text"></form>'));
+    expect(result).toBe('<form><input></form>');
+    expect(logged.join('\n')).toContain('page.html - Removing 2 native HTML default attribute(s)');
+  });
+
+  it('returns null when the file is untouched', async () => {
+    expect(await transform(fakeRoot('<input type="email">'))).toBeNull();
+    expect(logged).toEqual([]);
+  });
+
+  it('logs conditional skips with their reason, and still returns null when nothing is removed', async () => {
+    const result = await transform(fakeRoot('<button type="submit">Go</button>'));
+    expect(result).toBeNull();
+    expect(logged.join('\n')).toContain('ℹ️ page.html:1:9 - keeping <button> type="submit"');
+  });
+
+  it('is idempotent through the workflow contract (second pass returns null)', async () => {
+    const first = await transform(fakeRoot('<input type="text">'));
+    expect(first).toBe('<input>');
+    expect(await transform(fakeRoot(first as string))).toBeNull();
+  });
+});

--- a/packages/codemod-html-defaults/tests/defaults-data.spec.ts
+++ b/packages/codemod-html-defaults/tests/defaults-data.spec.ts
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { enumeratedAttributes, type Definition } from 'html-enumerated-attributes';
+import { conditionalAttributes, supplementaryRules } from '../src/defaults.js';
+import { transformHtml } from '../src/transform.js';
+
+/**
+ * The defaults data must never be trusted from memory: every default the
+ * codemod can act on is verified here against jsdom, which implements the
+ * WHATWG reflection rules ("missing value default") for form controls and
+ * embedded content. Attributes jsdom does not reflect are covered by the
+ * sourced entries in `supplementaryRules` and by the upstream
+ * `html-enumerated-attributes` data (itself generated against the spec).
+ */
+describe('empirical verification against jsdom (WHATWG reflection)', () => {
+  it.each([
+    ['input', 'type', 'text'],
+    ['form', 'method', 'get'],
+    ['form', 'enctype', 'application/x-www-form-urlencoded'],
+  ])('a bare <%s> reflects %s = %j', (tag, property, expected) => {
+    const element = document.createElement(tag) as unknown as Record<string, unknown>;
+    expect(element[property]).toBe(expected);
+  });
+
+  it('td/th colSpan and rowSpan default to 1 (not encoded as removable — documented candidate only)', () => {
+    const cell = document.createElement('td');
+    expect(cell.colSpan).toBe(1);
+    expect(cell.rowSpan).toBe(1);
+  });
+
+  it('button.type reflects "submit" when missing — and is still guarded as conditional, never removed flatly', () => {
+    expect(document.createElement('button').type).toBe('submit');
+    expect(conditionalAttributes.button.type).toBe('form-association');
+  });
+});
+
+describe('assumptions about the html-enumerated-attributes data', () => {
+  const allDefinitions: Definition[] = Object.values(enumeratedAttributes).flatMap(entry => (Array.isArray(entry) ? entry : [entry]));
+
+  it('selectors are plain comma-separated tag names (the transform relies on this)', () => {
+    for (const definition of allDefinitions) {
+      if (definition.selector === undefined) continue;
+      for (const part of definition.selector.split(',')) {
+        expect(part.trim()).toMatch(/^[a-z][a-z0-9]*$/);
+      }
+    }
+  });
+
+  it('a missing value default outside any state group means "never removable" (e.g. li[type]: missing is an unnamed state)', () => {
+    // The transform only removes a value whose state group CONTAINS the
+    // missing value default. When the missing default belongs to no group
+    // (an unnamed state), no literal value can ever match it — verified
+    // here on li[type], the one entry in the current data shaped that way.
+    const source = '<ul><li type="disc">x</li></ul>';
+    expect(transformHtml(source).output).toBe(source);
+  });
+
+  it('contains the defaults the codemod relies on, matching jsdom above', () => {
+    const type = enumeratedAttributes.type as Definition[];
+    expect(type.find(definition => definition.selector === 'input')?.missing).toBe('text');
+    expect((enumeratedAttributes.method as Definition).missing).toBe('get');
+    expect((enumeratedAttributes.enctype as Definition).missing).toBe('application/x-www-form-urlencoded');
+    expect((enumeratedAttributes.shape as Definition).missing).toBe('rect');
+    expect((enumeratedAttributes.loading as Definition).missing).toBe('eager');
+    expect((enumeratedAttributes.wrap as Definition).missing).toBe('soft');
+  });
+});
+
+describe('supplementary rules hygiene', () => {
+  const BOOLEAN_ATTRIBUTES = ['allowfullscreen', 'async', 'autofocus', 'checked', 'defer', 'disabled', 'hidden', 'multiple', 'open', 'readonly', 'required', 'selected'];
+
+  it('every entry is sourced to the WHATWG spec', () => {
+    for (const rule of supplementaryRules) {
+      expect(rule.source).toMatch(/^https:\/\/html\.spec\.whatwg\.org\//);
+      expect(rule.note.length).toBeGreaterThan(0);
+      expect(rule.equivalentToMissing.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('never lists a boolean attribute (presence must never be removed)', () => {
+    for (const rule of supplementaryRules) {
+      expect(BOOLEAN_ATTRIBUTES).not.toContain(rule.attribute);
+    }
+  });
+
+  it('defaults are stored lowercased so case-insensitive comparison works', () => {
+    for (const rule of supplementaryRules) {
+      for (const value of rule.equivalentToMissing) {
+        expect(value).toBe(value.toLowerCase());
+      }
+    }
+  });
+});

--- a/packages/codemod-html-defaults/tests/fixtures.spec.ts
+++ b/packages/codemod-html-defaults/tests/fixtures.spec.ts
@@ -1,0 +1,39 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { transformHtml } from '../src/transform.js';
+
+/**
+ * Conventional codemod golden tests: each `<name>.input.<ext>` file in
+ * ./fixtures is transformed and compared byte for byte to its
+ * `<name>.expected.<ext>` sibling. Fixtures whose expected file equals the
+ * input document the cases the codemod must leave alone.
+ */
+const FIXTURES_DIRECTORY = fileURLToPath(new URL('fixtures', import.meta.url));
+
+const fixtures = readdirSync(FIXTURES_DIRECTORY)
+  .filter(file => /\.input\.[^.]+$/.test(file))
+  .map(file => {
+    const expected = file.replace(/\.input\.([^.]+)$/, '.expected.$1');
+    return { name: file.replace(/\.input\.[^.]+$/, ''), input: file, expected };
+  });
+
+describe('fixtures', () => {
+  it('finds fixture pairs', () => {
+    expect(fixtures.length).toBeGreaterThan(0);
+  });
+
+  it.each(fixtures)('$name: input transforms into expected', ({ input, expected }) => {
+    const source = readFileSync(join(FIXTURES_DIRECTORY, input), 'utf8');
+    const expectedOutput = readFileSync(join(FIXTURES_DIRECTORY, expected), 'utf8');
+    expect(transformHtml(source).output).toBe(expectedOutput);
+  });
+
+  it.each(fixtures)('$name: expected output is stable (idempotence)', ({ expected }) => {
+    const expectedOutput = readFileSync(join(FIXTURES_DIRECTORY, expected), 'utf8');
+    const rerun = transformHtml(expectedOutput);
+    expect(rerun.output).toBe(expectedOutput);
+    expect(rerun.changed).toBe(false);
+  });
+});

--- a/packages/codemod-html-defaults/tests/fixtures/base-target.expected.html
+++ b/packages/codemod-html-defaults/tests/fixtures/base-target.expected.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <base target="_blank" href="https://example.com/">
+  </head>
+  <body>
+    <a target="_self" href="/">stays: base target is set</a>
+    <form target="_self" action="/s"><input name="q"></form>
+  </body>
+</html>

--- a/packages/codemod-html-defaults/tests/fixtures/base-target.input.html
+++ b/packages/codemod-html-defaults/tests/fixtures/base-target.input.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <base target="_blank" href="https://example.com/">
+  </head>
+  <body>
+    <a target="_self" href="/">stays: base target is set</a>
+    <form target="_self" action="/s"><input type="text" name="q"></form>
+  </body>
+</html>

--- a/packages/codemod-html-defaults/tests/fixtures/form.expected.html
+++ b/packages/codemod-html-defaults/tests/fixtures/form.expected.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Form</title>
+  </head>
+  <body>
+    <form action="/search">
+      <input name="q" required>
+      <input type="email" name="mail">
+      <select name="tags" multiple>
+        <option selected>a</option>
+      </select>
+      <textarea name="notes"></textarea>
+      <button type="submit">Go</button>
+      <button type="button">Cancel</button>
+    </form>
+  </body>
+</html>

--- a/packages/codemod-html-defaults/tests/fixtures/form.input.html
+++ b/packages/codemod-html-defaults/tests/fixtures/form.input.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Form</title>
+  </head>
+  <body>
+    <form method="get" enctype="application/x-www-form-urlencoded" autocomplete="on" action="/search">
+      <input type="text" name="q" required>
+      <input type="email" name="mail">
+      <select name="tags" multiple>
+        <option selected>a</option>
+      </select>
+      <textarea wrap="soft" name="notes"></textarea>
+      <button type="submit">Go</button>
+      <button type="button">Cancel</button>
+    </form>
+  </body>
+</html>

--- a/packages/codemod-html-defaults/tests/fixtures/full-document.expected.html
+++ b/packages/codemod-html-defaults/tests/fixtures/full-document.expected.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="main.css">
+    <link rel="preload" type="text/css" href="later.css" as="style">
+    <style>
+      body { margin: 0; }
+    </style>
+    <script>
+      init();
+    </script>
+    <script type="module" src="app.js"></script>
+  </head>
+  <body>
+    <a href="/">home</a>
+    <img src="hero.png" alt="">
+    <img src="below.png" alt="" loading="lazy">
+    <map name="m">
+      <area coords="0,0,10,10" href="/a" alt="a">
+    </map>
+  </body>
+</html>

--- a/packages/codemod-html-defaults/tests/fixtures/full-document.input.html
+++ b/packages/codemod-html-defaults/tests/fixtures/full-document.input.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" type="text/css" href="main.css">
+    <link rel="preload" type="text/css" href="later.css" as="style">
+    <style type="text/css">
+      body { margin: 0; }
+    </style>
+    <script type="text/javascript">
+      init();
+    </script>
+    <script type="module" src="app.js"></script>
+  </head>
+  <body>
+    <a target="_self" href="/">home</a>
+    <img src="hero.png" alt="" loading="eager" decoding="auto">
+    <img src="below.png" alt="" loading="lazy">
+    <map name="m">
+      <area shape="rect" coords="0,0,10,10" href="/a" alt="a">
+    </map>
+  </body>
+</html>

--- a/packages/codemod-html-defaults/tests/fixtures/no-changes.expected.html
+++ b/packages/codemod-html-defaults/tests/fixtures/no-changes.expected.html
@@ -1,0 +1,12 @@
+<section>
+  <input disabled>
+  <input required type="checkbox" checked>
+  <a target="">empty value stays</a>
+  <input type="text" type="email">
+  <my-input type="text"></my-input>
+  <svg><a target="_self"><text>svg</text></a></svg>
+  <script src="a.js" defer></script>
+  <script type="importmap">{ "imports": {} }</script>
+  <input type=" text ">
+  <ol type="I"><li type="disc">roman</li></ol>
+</section>

--- a/packages/codemod-html-defaults/tests/fixtures/no-changes.input.html
+++ b/packages/codemod-html-defaults/tests/fixtures/no-changes.input.html
@@ -1,0 +1,12 @@
+<section>
+  <input disabled>
+  <input required type="checkbox" checked>
+  <a target="">empty value stays</a>
+  <input type="text" type="email">
+  <my-input type="text"></my-input>
+  <svg><a target="_self"><text>svg</text></a></svg>
+  <script src="a.js" defer></script>
+  <script type="importmap">{ "imports": {} }</script>
+  <input type=" text ">
+  <ol type="I"><li type="disc">roman</li></ol>
+</section>

--- a/packages/codemod-html-defaults/tests/fixtures/nunjucks-template.expected.njk
+++ b/packages/codemod-html-defaults/tests/fixtures/nunjucks-template.expected.njk
@@ -1,0 +1,11 @@
+{% extends "layouts/base.njk" %}
+
+{% block content %}
+  <h1>{{ title }}</h1>
+  <form action="{{ searchUrl }}">
+    <input name="q" value="{{ query }}" placeholder="{% if fr %}Rechercher{% else %}Search{% endif %}">
+    <input type="{{ dynamicType }}" name="x">
+    <button type="submit">{{ label }}</button>
+  </form>
+  <a target="_self" href="{{ home }}">stays: fragment may be included under a layout with base</a>
+{% endblock %}

--- a/packages/codemod-html-defaults/tests/fixtures/nunjucks-template.input.njk
+++ b/packages/codemod-html-defaults/tests/fixtures/nunjucks-template.input.njk
@@ -1,0 +1,11 @@
+{% extends "layouts/base.njk" %}
+
+{% block content %}
+  <h1>{{ title }}</h1>
+  <form method="get" action="{{ searchUrl }}">
+    <input type="text" name="q" value="{{ query }}" placeholder="{% if fr %}Rechercher{% else %}Search{% endif %}">
+    <input type="{{ dynamicType }}" name="x">
+    <button type="submit">{{ label }}</button>
+  </form>
+  <a target="_self" href="{{ home }}">stays: fragment may be included under a layout with base</a>
+{% endblock %}

--- a/packages/codemod-html-defaults/tests/functional-noop.spec.ts
+++ b/packages/codemod-html-defaults/tests/functional-noop.spec.ts
@@ -1,0 +1,57 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { transformHtml } from '../src/transform.js';
+
+/**
+ * Functional no-op proof (not a snapshot): the transformed document must
+ * expose the exact same form submission behavior as the original, as
+ * reflected by the WHATWG IDL attributes jsdom implements.
+ */
+describe('functional no-op on forms', () => {
+  const source = `<!doctype html>
+<html><body>
+<form method="get" enctype="application/x-www-form-urlencoded" autocomplete="on" action="/search">
+  <input type="text" name="q" required>
+  <select name="s"><option selected>a</option></select>
+  <textarea wrap="soft" name="t"></textarea>
+  <button type="submit">Go</button>
+</form>
+</body></html>`;
+
+  const probe = (html: string) => {
+    const { window } = new JSDOM(html, { url: 'https://example.com/' });
+    const document = window.document;
+    const form = document.forms[0];
+    const input = document.querySelector('input')!;
+    const button = document.querySelector('button')!;
+    const textarea = document.querySelector('textarea')!;
+    return {
+      method: form.method,
+      enctype: form.enctype,
+      action: form.action,
+      inputType: input.type,
+      inputRequired: input.required,
+      inputName: input.name,
+      buttonType: button.type,
+      textareaName: textarea.name,
+      elementCount: form.elements.length,
+    };
+  };
+
+  it('submission-related behavior is identical before and after the transform', () => {
+    const { output, changed } = transformHtml(source);
+    expect(changed).toBe(true);
+    expect(probe(output)).toEqual(probe(source));
+  });
+
+  it('the transform removed the redundant attributes it claims to', () => {
+    const { output } = transformHtml(source);
+    expect(output).not.toContain('method="get"');
+    expect(output).not.toContain('type="text"');
+    expect(output).not.toContain('enctype=');
+    expect(output).not.toContain('wrap="soft"');
+    // Conditional case: left in place.
+    expect(output).toContain('type="submit"');
+  });
+});

--- a/packages/codemod-html-defaults/tests/transform.spec.ts
+++ b/packages/codemod-html-defaults/tests/transform.spec.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+import { transformHtml } from '../src/transform.js';
+
+const removedAttributes = (source: string) => transformHtml(source).findings.filter(finding => finding.type === 'removed');
+const skippedAttributes = (source: string) => transformHtml(source).findings.filter(finding => finding.type === 'skipped');
+
+describe('button[type] conditional case (written before any flat rule — must never be treated as a flat default)', () => {
+  it('does not remove type="submit" from a button inside a form', () => {
+    const source = '<form action="/x"><button type="submit">Go</button></form>';
+    const result = transformHtml(source);
+    expect(result.output).toBe(source);
+    expect(skippedAttributes(source)).toMatchObject([{ tag: 'button', attribute: 'type', value: 'submit' }]);
+  });
+
+  it('does not remove type="submit" from a button outside a form either', () => {
+    const source = '<button type="submit">Go</button>';
+    expect(transformHtml(source).output).toBe(source);
+    expect(skippedAttributes(source)[0].reason).toContain('form association');
+  });
+
+  it('leaves non-default button types alone silently', () => {
+    const source = '<button type="button">Go</button>';
+    expect(transformHtml(source).output).toBe(source);
+  });
+});
+
+describe('literal value equal to the spec default', () => {
+  it.each([
+    ['<input type="text">', '<input>'],
+    ['<form method="get"></form>', '<form></form>'],
+    ['<form method="GET"></form>', '<form></form>'],
+    ['<form enctype="application/x-www-form-urlencoded"></form>', '<form></form>'],
+    ['<form autocomplete="on"></form>', '<form></form>'],
+    ['<img src="a.png" decoding="auto">', '<img src="a.png">'],
+    ['<img src="a.png" loading="eager">', '<img src="a.png">'],
+    ['<area shape="rect">', '<area>'],
+    ['<textarea wrap="soft"></textarea>', '<textarea></textarea>'],
+    ['<script type="text/javascript">x()</script>', '<script>x()</script>'],
+    ['<style type="text/css">a{}</style>', '<style>a{}</style>'],
+    ['<link rel="stylesheet" type="text/css" href="a.css">', '<link rel="stylesheet" href="a.css">'],
+  ])('%s → %s', (source, expected) => {
+    expect(transformHtml(source).output).toBe(expected);
+  });
+
+  it('keeps surrounding attributes and whitespace intact', () => {
+    expect(transformHtml('<input class="a" type="text" required>').output).toBe('<input class="a" required>');
+  });
+});
+
+describe('literal value different from the default', () => {
+  it.each([
+    '<input type="email">',
+    '<form method="post"></form>',
+    '<script type="module">x()</script>',
+    '<script type="importmap">{}</script>',
+    '<img src="a.png" loading="lazy">',
+  ])('leaves %s untouched', source => {
+    const result = transformHtml(source);
+    expect(result.output).toBe(source);
+    expect(result.findings).toEqual([]);
+  });
+
+  it('does not confuse defaults across attributes whose meaning depends on the effective type', () => {
+    const source = '<input type="number" size="20">';
+    expect(transformHtml(source).output).toBe(source);
+  });
+});
+
+describe('dynamic bindings and interpolations', () => {
+  it.each(['<input type="{{ inputType }}">', '<input type="{% if x %}text{% endif %}">', '<form method="<%= method %>"></form>', '<input type="$' + '{type}">'])(
+    'never removes %s',
+    source => {
+      const result = transformHtml(source);
+      expect(result.output).toBe(source);
+      expect(result.findings).toMatchObject([{ type: 'skipped' }]);
+    },
+  );
+
+  it('never matches framework binding attribute names (Vue/Angular prefixes)', () => {
+    const source = '<input :type="x" v-bind:type="y" ng-type="z">';
+    expect(transformHtml(source).output).toBe(source);
+  });
+
+  it('preserves template syntax outside removed attributes byte for byte', () => {
+    const source = '{% block content %}<p>{{ title }}</p><input type="text">{% endblock %}';
+    expect(transformHtml(source).output).toBe('{% block content %}<p>{{ title }}</p><input>{% endblock %}');
+  });
+});
+
+describe('boolean attributes', () => {
+  it.each([
+    '<input disabled>',
+    '<input required>',
+    '<input checked type="checkbox">',
+    '<select multiple></select>',
+    '<script src="a.js" defer></script>',
+    '<details open></details>',
+  ])('never removes the boolean presence in %s', source => {
+    expect(transformHtml(source).output).toBe(source);
+  });
+
+  it('never removes an attribute with an empty value, even when the empty string is the missing value default', () => {
+    const source = '<a target="">x</a>';
+    expect(transformHtml(source).output).toBe(source);
+  });
+});
+
+describe('target and <base target> (real condition, not a flat default)', () => {
+  const fullDocument = (body: string, head = '') => `<!doctype html>\n<html><head>${head}</head><body>${body}</body></html>`;
+
+  it('removes target="_self" in a full document without <base target>', () => {
+    const result = transformHtml(fullDocument('<a target="_self" href="/x">x</a>'));
+    expect(result.output).toBe(fullDocument('<a href="/x">x</a>'));
+  });
+
+  it('keeps target="_self" when a <base target> exists anywhere in the document', () => {
+    const source = fullDocument('<a target="_self" href="/x">x</a>', '<base target="_blank">');
+    const result = transformHtml(source);
+    expect(result.output).toBe(source);
+    expect(result.findings).toMatchObject([{ type: 'skipped', tag: 'a', attribute: 'target' }]);
+  });
+
+  it('keeps target="_self" in a fragment (a partial may be included under a layout with <base>)', () => {
+    const source = '<a target="_self" href="/x">x</a>';
+    const result = transformHtml(source);
+    expect(result.output).toBe(source);
+    expect(result.findings).toMatchObject([{ type: 'skipped' }]);
+  });
+
+  it('never removes target from <base> itself', () => {
+    const source = fullDocument('', '<base target="_self">');
+    expect(transformHtml(source).output).toBe(source);
+  });
+});
+
+describe('link[type] depends on rel="stylesheet" (real condition)', () => {
+  it('keeps type="text/css" when rel is not stylesheet', () => {
+    const source = '<link rel="preload" type="text/css" href="a.css">';
+    const result = transformHtml(source);
+    expect(result.output).toBe(source);
+    expect(result.findings).toMatchObject([{ type: 'skipped' }]);
+  });
+
+  it('keeps type="text/css" when rel is dynamic', () => {
+    const source = '<link rel="{{ rel }}" type="text/css" href="a.css">';
+    expect(transformHtml(source).output).toBe(source);
+  });
+
+  it('handles multi-token rel values', () => {
+    expect(transformHtml('<link rel="alternate stylesheet" type="text/css" href="a.css">').output).toBe('<link rel="alternate stylesheet" href="a.css">');
+  });
+});
+
+describe('value normalization', () => {
+  it('is ASCII case-insensitive for enumerated and MIME values', () => {
+    expect(transformHtml('<input TYPE="TeXt">').output).toBe('<input>');
+    expect(transformHtml('<script type="Text/JavaScript">x()</script>').output).toBe('<script>x()</script>');
+  });
+
+  it('respects case-sensitive enumerated attributes (ol[type])', () => {
+    expect(transformHtml('<ol type="1"><li>a</li></ol>').output).toBe('<ol><li>a</li></ol>');
+    const source = '<ol type="I"><li>a</li></ol>';
+    expect(transformHtml(source).output).toBe(source);
+  });
+
+  it('handles single quotes and no quotes', () => {
+    expect(transformHtml("<input type='text'>").output).toBe('<input>');
+    expect(transformHtml('<input type=text>').output).toBe('<input>');
+  });
+
+  it('does not trim: a padded value is not an exact state match and is kept', () => {
+    const source = '<input type=" text ">';
+    expect(transformHtml(source).output).toBe(source);
+  });
+});
+
+describe('safety guards', () => {
+  it('skips a start tag containing duplicate attributes', () => {
+    const source = '<input type="text" type="email">';
+    expect(transformHtml(source).output).toBe(source);
+  });
+
+  it('ignores foreign (SVG) content sharing attribute names with HTML', () => {
+    const source = '<svg><a target="_self"><text>x</text></a></svg>';
+    expect(transformHtml(source).output).toBe(source);
+  });
+
+  it('processes elements inside <template>', () => {
+    expect(transformHtml('<template><input type="text"></template>').output).toBe('<template><input></template>');
+  });
+
+  it('never touches custom elements', () => {
+    const source = '<my-input type="text"></my-input>';
+    expect(transformHtml(source).output).toBe(source);
+  });
+});
+
+describe('idempotence', () => {
+  it('a second run produces zero changes', () => {
+    const source = '<!doctype html>\n<html><body><form method="get"><input type="text"><button type="submit">Go</button></form><a target="_self" href="/">x</a></body></html>';
+    const first = transformHtml(source);
+    expect(first.changed).toBe(true);
+    const second = transformHtml(first.output);
+    expect(second.changed).toBe(false);
+    expect(second.output).toBe(first.output);
+    expect(second.findings.filter(finding => finding.type === 'removed')).toEqual([]);
+  });
+});
+
+describe('report', () => {
+  it('reports line and column of each removal', () => {
+    const findings = removedAttributes('<div>\n  <input type="text">\n</div>');
+    expect(findings).toMatchObject([{ tag: 'input', attribute: 'type', value: 'text', line: 2, column: 10 }]);
+  });
+});

--- a/packages/codemod-html-defaults/tsconfig.json
+++ b/packages/codemod-html-defaults/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "declaration": true,
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "lib": ["ES2022"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/codemod-html-defaults/vite.config.mjs
+++ b/packages/codemod-html-defaults/vite.config.mjs
@@ -7,6 +7,7 @@ export default defineConfig({
       entry: {
         index: 'src/index.ts',
         cli: 'src/cli.ts',
+        codemod: 'src/codemod.ts',
       },
       formats: ['es'],
       fileName: (format, entryName) => `${entryName}.js`,

--- a/packages/codemod-html-defaults/vite.config.mjs
+++ b/packages/codemod-html-defaults/vite.config.mjs
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: {
+        index: 'src/index.ts',
+        cli: 'src/cli.ts',
+      },
+      formats: ['es'],
+      fileName: (format, entryName) => `${entryName}.js`,
+    },
+    rollupOptions: {
+      external: [/^node:/, 'parse5', 'html-enumerated-attributes'],
+    },
+    target: 'node20',
+    ssr: true,
+  },
+  plugins: [dts()],
+});

--- a/packages/codemod-html-defaults/vitest.config.mjs
+++ b/packages/codemod-html-defaults/vitest.config.mjs
@@ -1,0 +1,9 @@
+export default {
+  test: {
+    environment: 'node',
+    coverage: {
+      reporter: ['text', 'html'],
+      include: ['src/**'],
+    },
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@changesets/cli':
         specifier: 2.30.0
-        version: 2.30.0(@types/node@25.3.5)
+        version: 2.30.0(@types/node@26.1.1)
       '@dume/linting':
         specifier: workspace:*
         version: link:packages/linting
@@ -89,7 +89,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.3.5)(sass@1.97.3)(yaml@2.8.2)
+        version: 7.3.1(@types/node@26.1.1)(sass@1.97.3)(yaml@2.8.2)
 
   apps/simon.duhem.fr:
     devDependencies:
@@ -104,13 +104,44 @@ importers:
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.3.5)(sass@1.97.3)(yaml@2.8.2)
+        version: 7.3.1(@types/node@26.1.1)(sass@1.97.3)(yaml@2.8.2)
 
   apps/slides:
     devDependencies:
       '@marp-team/marp-cli':
         specifier: 4.2.3
         version: 4.2.3(typescript@5.9.3)
+
+  packages/codemod-html-defaults:
+    dependencies:
+      html-enumerated-attributes:
+        specifier: 1.1.1
+        version: 1.1.1
+      parse5:
+        specifier: 8.0.1
+        version: 8.0.1
+    devDependencies:
+      '@types/node':
+        specifier: 26.1.1
+        version: 26.1.1
+      '@vitest/coverage-v8':
+        specifier: 4.0.18
+        version: 4.0.18(vitest@4.0.18(@types/node@26.1.1)(jsdom@28.1.0)(sass@1.97.3)(yaml@2.8.2))
+      jsdom:
+        specifier: 28.1.0
+        version: 28.1.0
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vite:
+        specifier: 7.3.1
+        version: 7.3.1(@types/node@26.1.1)(sass@1.97.3)(yaml@2.8.2)
+      vite-plugin-dts:
+        specifier: 4.5.4
+        version: 4.5.4(@types/node@26.1.1)(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.1(@types/node@26.1.1)(sass@1.97.3)(yaml@2.8.2))
+      vitest:
+        specifier: 4.0.18
+        version: 4.0.18(@types/node@26.1.1)(jsdom@28.1.0)(sass@1.97.3)(yaml@2.8.2)
 
   packages/linting:
     devDependencies:
@@ -158,7 +189,7 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 4.0.18
-        version: 4.0.18(vitest@4.0.18(@types/node@25.3.5)(jsdom@28.1.0)(sass@1.97.3)(yaml@2.8.2))
+        version: 4.0.18(vitest@4.0.18(@types/node@26.1.1)(jsdom@28.1.0)(sass@1.97.3)(yaml@2.8.2))
       jsdom:
         specifier: 28.1.0
         version: 28.1.0
@@ -173,13 +204,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.3.5)(sass@1.97.3)(yaml@2.8.2)
+        version: 7.3.1(@types/node@26.1.1)(sass@1.97.3)(yaml@2.8.2)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@25.3.5)(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.5)(sass@1.97.3)(yaml@2.8.2))
+        version: 4.5.4(@types/node@26.1.1)(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.1(@types/node@26.1.1)(sass@1.97.3)(yaml@2.8.2))
       vitest:
         specifier: 4.0.18
-        version: 4.0.18(@types/node@25.3.5)(jsdom@28.1.0)(sass@1.97.3)(yaml@2.8.2)
+        version: 4.0.18(@types/node@26.1.1)(jsdom@28.1.0)(sass@1.97.3)(yaml@2.8.2)
 
 packages:
 
@@ -1253,8 +1284,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@25.3.5':
-    resolution: {integrity: sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==}
+  '@types/node@26.1.1':
+    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -1909,6 +1940,10 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
@@ -2269,6 +2304,9 @@ packages:
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-enumerated-attributes@1.1.1:
+    resolution: {integrity: sha512-fxfswuADQ6N6RmCUYoCEIw09Zbk/h8GJSJsbiQ3Uw3mkQegJ5b7Eu5Tpxl2xDUq9meWmivHe0GFieG2qHl2j4A==}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -2983,8 +3021,8 @@ packages:
   parse-srcset@1.0.2:
     resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
 
-  parse5@8.0.0:
-    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -3649,8 +3687,8 @@ packages:
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   undici@7.22.0:
     resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
@@ -4135,7 +4173,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.30.0(@types/node@25.3.5)':
+  '@changesets/cli@2.30.0(@types/node@26.1.1)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.0
       '@changesets/assemble-release-plan': 6.0.9
@@ -4151,7 +4189,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@25.3.5)
+      '@inquirer/external-editor': 1.0.3(@types/node@26.1.1)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
@@ -4551,12 +4589,12 @@ snapshots:
   '@img/sharp-win32-x64@0.33.5':
     optional: true
 
-  '@inquirer/external-editor@1.0.3(@types/node@25.3.5)':
+  '@inquirer/external-editor@1.0.3(@types/node@26.1.1)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 25.3.5
+      '@types/node': 26.1.1
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -4673,23 +4711,23 @@ snapshots:
       postcss: 8.5.8
       postcss-nesting: 13.0.2(postcss@8.5.8)
 
-  '@microsoft/api-extractor-model@7.33.4(@types/node@25.3.5)':
+  '@microsoft/api-extractor-model@7.33.4(@types/node@26.1.1)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.20.3(@types/node@25.3.5)
+      '@rushstack/node-core-library': 5.20.3(@types/node@26.1.1)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.57.6(@types/node@25.3.5)':
+  '@microsoft/api-extractor@7.57.6(@types/node@26.1.1)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.33.4(@types/node@25.3.5)
+      '@microsoft/api-extractor-model': 7.33.4(@types/node@26.1.1)
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.20.3(@types/node@25.3.5)
+      '@rushstack/node-core-library': 5.20.3(@types/node@26.1.1)
       '@rushstack/rig-package': 0.7.2
-      '@rushstack/terminal': 0.22.3(@types/node@25.3.5)
-      '@rushstack/ts-command-line': 5.3.3(@types/node@25.3.5)
+      '@rushstack/terminal': 0.22.3(@types/node@26.1.1)
+      '@rushstack/ts-command-line': 5.3.3(@types/node@26.1.1)
       diff: 8.0.3
       lodash: 4.17.23
       minimatch: 10.2.1
@@ -4896,7 +4934,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
-  '@rushstack/node-core-library@5.20.3(@types/node@25.3.5)':
+  '@rushstack/node-core-library@5.20.3(@types/node@26.1.1)':
     dependencies:
       ajv: 8.18.0
       ajv-draft-04: 1.0.0(ajv@8.18.0)
@@ -4907,28 +4945,28 @@ snapshots:
       resolve: 1.22.11
       semver: 7.5.4
     optionalDependencies:
-      '@types/node': 25.3.5
+      '@types/node': 26.1.1
 
-  '@rushstack/problem-matcher@0.2.1(@types/node@25.3.5)':
+  '@rushstack/problem-matcher@0.2.1(@types/node@26.1.1)':
     optionalDependencies:
-      '@types/node': 25.3.5
+      '@types/node': 26.1.1
 
   '@rushstack/rig-package@0.7.2':
     dependencies:
       resolve: 1.22.11
       strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.22.3(@types/node@25.3.5)':
+  '@rushstack/terminal@0.22.3(@types/node@26.1.1)':
     dependencies:
-      '@rushstack/node-core-library': 5.20.3(@types/node@25.3.5)
-      '@rushstack/problem-matcher': 0.2.1(@types/node@25.3.5)
+      '@rushstack/node-core-library': 5.20.3(@types/node@26.1.1)
+      '@rushstack/problem-matcher': 0.2.1(@types/node@26.1.1)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 25.3.5
+      '@types/node': 26.1.1
 
-  '@rushstack/ts-command-line@5.3.3(@types/node@25.3.5)':
+  '@rushstack/ts-command-line@5.3.3(@types/node@26.1.1)':
     dependencies:
-      '@rushstack/terminal': 0.22.3(@types/node@25.3.5)
+      '@rushstack/terminal': 0.22.3(@types/node@26.1.1)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -5012,16 +5050,15 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@25.3.5':
+  '@types/node@26.1.1':
     dependencies:
-      undici-types: 7.18.2
-    optional: true
+      undici-types: 8.3.0
 
   '@types/unist@3.0.3': {}
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 25.3.5
+      '@types/node': 26.1.1
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@10.0.2)(typescript@5.9.3))(eslint@10.0.2)(typescript@5.9.3)':
@@ -5115,7 +5152,7 @@ snapshots:
       '@typescript-eslint/types': 8.54.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.3.5)(jsdom@28.1.0)(sass@1.97.3)(yaml@2.8.2))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@26.1.1)(jsdom@28.1.0)(sass@1.97.3)(yaml@2.8.2))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -5127,7 +5164,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@25.3.5)(jsdom@28.1.0)(sass@1.97.3)(yaml@2.8.2)
+      vitest: 4.0.18(@types/node@26.1.1)(jsdom@28.1.0)(sass@1.97.3)(yaml@2.8.2)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -5138,13 +5175,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.3.5)(sass@1.97.3)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@26.1.1)(sass@1.97.3)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.3.5)(sass@1.97.3)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@26.1.1)(sass@1.97.3)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -5654,6 +5691,8 @@ snapshots:
 
   entities@7.0.1: {}
 
+  entities@8.0.0: {}
+
   env-paths@2.2.1: {}
 
   environment@1.1.0: {}
@@ -6050,6 +6089,8 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  html-enumerated-attributes@1.1.1: {}
+
   html-escaper@2.0.2: {}
 
   html-tags@5.1.0: {}
@@ -6224,7 +6265,7 @@ snapshots:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
-      parse5: 8.0.0
+      parse5: 8.0.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.0
@@ -6926,9 +6967,9 @@ snapshots:
 
   parse-srcset@1.0.2: {}
 
-  parse5@8.0.0:
+  parse5@8.0.1:
     dependencies:
-      entities: 6.0.1
+      entities: 8.0.0
 
   parseurl@1.3.3: {}
 
@@ -7671,8 +7712,7 @@ snapshots:
 
   ufo@1.6.3: {}
 
-  undici-types@7.18.2:
-    optional: true
+  undici-types@8.3.0: {}
 
   undici@7.22.0: {}
 
@@ -7713,9 +7753,9 @@ snapshots:
 
   validate-npm-package-name@6.0.2: {}
 
-  vite-plugin-dts@4.5.4(@types/node@25.3.5)(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.5)(sass@1.97.3)(yaml@2.8.2)):
+  vite-plugin-dts@4.5.4(@types/node@26.1.1)(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.1(@types/node@26.1.1)(sass@1.97.3)(yaml@2.8.2)):
     dependencies:
-      '@microsoft/api-extractor': 7.57.6(@types/node@25.3.5)
+      '@microsoft/api-extractor': 7.57.6(@types/node@26.1.1)
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
       '@volar/typescript': 2.4.28
       '@vue/language-core': 2.2.0(typescript@5.9.3)
@@ -7726,13 +7766,13 @@ snapshots:
       magic-string: 0.30.21
       typescript: 5.9.3
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.3.5)(sass@1.97.3)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@26.1.1)(sass@1.97.3)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite@7.3.1(@types/node@25.3.5)(sass@1.97.3)(yaml@2.8.2):
+  vite@7.3.1(@types/node@26.1.1)(sass@1.97.3)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -7741,15 +7781,15 @@ snapshots:
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.3.5
+      '@types/node': 26.1.1
       fsevents: 2.3.3
       sass: 1.97.3
       yaml: 2.8.2
 
-  vitest@4.0.18(@types/node@25.3.5)(jsdom@28.1.0)(sass@1.97.3)(yaml@2.8.2):
+  vitest@4.0.18(@types/node@26.1.1)(jsdom@28.1.0)(sass@1.97.3)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.5)(sass@1.97.3)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@26.1.1)(sass@1.97.3)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -7766,10 +7806,10 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.3.5)(sass@1.97.3)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@26.1.1)(sass@1.97.3)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.3.5
+      '@types/node': 26.1.1
       jsdom: 28.1.0
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
New package **`@dume/codemod-html-defaults`**: a CLI + library that removes native HTML attributes whose literal value is already the WHATWG spec default — e.g. `<input type="text">` → `<input>`, `<form method="get">` → `<form>`, `<script type="text/javascript">` → `<script>`.

## Usage

```sh
npx codemod-html-defaults src/                    # dry-run (default): per-attribute report, writes nothing
npx codemod-html-defaults --write src/            # apply
npx codemod-html-defaults --ext html,njk --write . # opt template files in when walking directories
```

Runs are idempotent, and edits are byte-preserving outside the removed attribute ranges (parse5 + source locations), so HTML-shaped templates like the Nunjucks files in `apps/articles` are safe.

## Where the defaults come from (nothing from memory)

- Primary source: [`html-enumerated-attributes`](https://github.com/wooorm/html-enumerated-attributes) (MIT, unified collective), which encodes the WHATWG *missing value defaults* as state equivalence classes. A value is removable only when it belongs to the same state group as the missing value default.
- A small spec-linked supplementary table in `src/defaults.ts` for the non-enumerated cases (`script[type]`, `style[type]`, `link[type]`), cross-checked with `html-minifier-terser`'s redundant-attribute handling.
- Empirical verification in tests against jsdom's WHATWG reflection (`input.type === 'text'`, `form.method === 'get'`, `button.type === 'submit'`, …).

## Conditional defaults — never applied flatly

- `button[type="submit"]`: never removed in v1, only reported (behavior depends on form association; explicit types are often kept for readability).
- `target="_self"` on `a`/`area`/`form`: removed only in a full document with no `<base target>`; fragments are always skipped (a partial may be included under a layout with `<base>`); `target` on `<base>` itself is never touched.
- `link[type="text/css"]`: removed only when the element's static `rel` contains the `stylesheet` token.

## Never touched

Dynamic values (`{{ }}`, `{% %}`, `<%= %>`, `${}`) and binding attribute names (`:type`, `v-bind:`, `ng-*`), boolean attributes and empty values, custom elements, foreign (SVG/MathML) content, and start tags containing duplicate attributes.

## Verification

- 73 tests, 96.7% statement coverage: removal matrix, dynamic/boolean guards, conditional cases (button in/out of form written before any rule), normalization (case, quotes, no trimming), idempotence, duplicate-attribute safety, CLI dry-run/write.
- Functional no-op proven on form submission behavior (method/enctype/type/required/elements identical before and after in jsdom) — not just snapshots.
- Dry-run on this repo's own `apps/`: 7 files scanned, 0 changes (repo already clean; `type="module"` correctly untouched).
- `pnpm lint`, `manypkg check` and the package's `vite build` all pass. Note: `slides#build` fails in turbo on `main` too (marp-cli browser discovery, environment issue) — unrelated to this change.

A changeset is included for the initial 1.0.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjF61pCbakF8bMW4XaaFeW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjF61pCbakF8bMW4XaaFeW)_